### PR TITLE
Make file separator platform-independent when storing properties

### DIFF
--- a/src/com/jtulayan/ui/javafx/PropWrapper.java
+++ b/src/com/jtulayan/ui/javafx/PropWrapper.java
@@ -35,6 +35,6 @@ public class PropWrapper {
     }
 
     public static void storeProperties() throws IOException {
-        propInstance.store(new FileOutputStream(propFile), "Properites");
+        propInstance.store(new FileOutputStream(propFile), "Properties");
     }
 }

--- a/src/com/jtulayan/ui/javafx/PropWrapper.java
+++ b/src/com/jtulayan/ui/javafx/PropWrapper.java
@@ -9,7 +9,7 @@ public class PropWrapper {
 
     private static final String PROP_NAME = "mpg";
     private static final String DIR_NAME = "motion-profile-generator";
-    private static final File APPDATA_DIR = new File(System.getProperty("user.home") + "\\." + DIR_NAME);
+    private static final File APPDATA_DIR = new File(System.getProperty("user.home") + File.separator + "." + DIR_NAME);
 
     public static Properties getProperties() {
         if (propInstance == null) {


### PR DESCRIPTION
Was going to create an issue for this but it turned out to be an easy fix. Without this, you get a `FileNotFoundException` on OSX (and presumably Linux) whenever exiting the setting dialog.

Also fixes a typo from "properites" to "properties".